### PR TITLE
Reset dataSetId cache on fetch failure

### DIFF
--- a/TidepoolServiceKit/TidepoolService.swift
+++ b/TidepoolServiceKit/TidepoolService.swift
@@ -212,9 +212,16 @@ public final class TidepoolService: Service, TAPIObserver, ObservableObject {
         }
 
         dataSetIdCacheStatus = .inProgress(task)
-        let dataSetId = try await task.value
-        dataSetIdCacheStatus = .fetched(dataSetId)
-        return dataSetId
+        do {
+            let dataSetId = try await task.value
+            dataSetIdCacheStatus = .fetched(dataSetId)
+            return dataSetId
+        } catch {
+            // Clear the cache so a transient failure (e.g. no network on the first upload)
+            // doesn't leave a failed task cached and poison every later upload until re-login.
+            clearCachedDataSetId()
+            throw error
+        }
     }
 
     private func fetchDataSetId() async throws -> String {


### PR DESCRIPTION
## Problem

`getCachedDataSetId()` caches the in-flight fetch task in `dataSetIdCacheStatus = .inProgress(task)`, but if that first fetch throws (e.g. no network at the moment of the first upload, or a transient server error), the failed task stays cached. Every subsequent upload awaits the same already-completed task and re-throws the same cached error — indefinitely. The service never retries the fetch, so uploads are dead until the user logs out of Tidepool and back in, which recreates the service.

This is one of the failure modes behind nightscout/Trio#1235 — it matches the report there of a user getting insulin/carbs in Tidepool but never glucose or therapy settings, with Trio missing from the Devices tab (the data set was never created, and the failure was cached).

## Fix

Wrap the awaited task in `do/catch` and call `clearCachedDataSetId()` on failure before re-throwing, so the next upload attempt retries a fresh fetch instead of replaying the poisoned cache.

## Notes

- This code is unchanged in upstream `LoopKit/TidepoolService`, so Loop is affected by the same latent bug; happy to open a parallel PR upstream.
- nightscout/Trio branch `fix/tidepool-serialize-uploads-1235` pins this commit for its Tidepool upload fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)